### PR TITLE
remove type string for text properties in nodes

### DIFF
--- a/ttn-app/ttn-app.html
+++ b/ttn-app/ttn-app.html
@@ -29,7 +29,6 @@
     defaults: {
       appId: {
         value: "",
-        type: "string",
         required: true,
       },
       accessKey: {
@@ -39,7 +38,6 @@
       },
       discovery: {
         value: "discovery.thethingsnetwork.org:1900",
-        type: "string",
         required: true,
       },
     },

--- a/ttn-downlink/ttn-downlink.html
+++ b/ttn-downlink/ttn-downlink.html
@@ -49,7 +49,6 @@
     defaults: {
       name: {
         value: "",
-        type: "string",
         required: false,
       },
       app: {
@@ -58,7 +57,6 @@
       },
       dev_id: {
         value: "",
-        type: "string",
         required: false,
       },
       port: {
@@ -72,7 +70,6 @@
       },
       schedule: {
         value: "replace",
-        type: "string",
         required: true,
       },
     },

--- a/ttn-event/ttn-event.html
+++ b/ttn-event/ttn-event.html
@@ -34,7 +34,6 @@
     defaults: {
       name: {
         value: "",
-        type: "string",
         required: false,
       },
       app: {
@@ -43,12 +42,10 @@
       },
       dev_id: {
         value: "",
-        type: "string",
         required: false,
       },
       event: {
         value: "#",
-        type: "string",
         required: true,
       },
     },

--- a/ttn-uplink/ttn-uplink.html
+++ b/ttn-uplink/ttn-uplink.html
@@ -35,7 +35,6 @@
     defaults: {
       name: {
         value: "",
-        type: "string",
         required: false,
       },
       app: {
@@ -44,12 +43,10 @@
       },
       dev_id: {
         value: "",
-        type: "string",
         required: false,
       },
       field: {
         value: "",
-        type: "string",
         required: false,
       },
     },


### PR DESCRIPTION
Solution for #52.

The type of the configuration items does not have to be set to 'string', you can leave it out and it will still be a text field. Currently the TTN configuration is incorrectly invoking another Node-RED contrib node called 'string'. This makes it impossible to properly configure the TTN nodes.